### PR TITLE
Add missing libraries to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For more details about how PDF OCR extraction work here, see section on [PDF OCR
 
 #### Example
 
-    aws lambda invoke --function-name textractor_ocr --payload '{"document_uri": "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf", "temp_uri_prefix": "s3://docbot-hippocrates-assets/", "text_uri": "s3://docbot-hippocrates-assets/tracemonkey.txt", "searchable_pdf_uri": "s3://docbot-hippocrates-assets/tracemonkey.searchable.pdf"}' -
+    aws lambda invoke --function-name textractor_ocr --payload '{"document_uri": "https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf", "temp_uri_prefix": "s3://bucket/", "text_uri": "s3://bucket/tracemonkey.txt", "searchable_pdf_uri": "s3://bucket/tracemonkey.searchable.pdf"}' -
 
     aws s3 cp s3://bucket/tracemonkey-5.txt -
 

--- a/functions/ocr/lib/pdftotext
+++ b/functions/ocr/lib/pdftotext
@@ -1,0 +1,1 @@
+../../../lib-linux_x64/pdftotext

--- a/functions/ocr/lib/tesseract
+++ b/functions/ocr/lib/tesseract
@@ -1,0 +1,1 @@
+../../../lib-linux_x64/tesseract/

--- a/functions/simple/lib/antiword
+++ b/functions/simple/lib/antiword
@@ -1,0 +1,1 @@
+../../../lib-linux_x64/antiword/

--- a/functions/simple/lib/catdoc
+++ b/functions/simple/lib/catdoc
@@ -1,0 +1,1 @@
+../../../lib-linux_x64/catdoc

--- a/functions/simple/lib/pdftotext
+++ b/functions/simple/lib/pdftotext
@@ -1,0 +1,1 @@
+../../../lib-linux_x64/pdftotext

--- a/functions/simple/lib/unrtf
+++ b/functions/simple/lib/unrtf
@@ -1,0 +1,1 @@
+../../../lib-linux_x64/unrtf


### PR DESCRIPTION
Fixes #4 

Soft links for `lib` files were missing from the repository because the `.gitignore` file for Python from Github includes `lib` folders. As a a result, most of the binary executables necessary for text extraction were unable to run successfully.

## Proposed Changes
  - Add the missing `lib`s with soft links to the repository
